### PR TITLE
Test availability

### DIFF
--- a/adapters/db/availability.sql.go
+++ b/adapters/db/availability.sql.go
@@ -203,6 +203,43 @@ func (q *Queries) Get_Availability(ctx context.Context, arg Get_AvailabilityPara
 	return items, nil
 }
 
+const get_Diagnostic_Availability = `-- name: Get_Diagnostic_Availability :many
+SELECT id, diagnostic_centre_id, day_of_week, start_time, end_time, max_appointments, slot_duration, break_time, created_at, updated_at FROM diagnostic_centre_availability
+WHERE diagnostic_centre_id = $1
+ORDER BY created_at ASC
+`
+
+func (q *Queries) Get_Diagnostic_Availability(ctx context.Context, diagnosticCentreID string) ([]*DiagnosticCentreAvailability, error) {
+	rows, err := q.db.Query(ctx, get_Diagnostic_Availability, diagnosticCentreID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []*DiagnosticCentreAvailability
+	for rows.Next() {
+		var i DiagnosticCentreAvailability
+		if err := rows.Scan(
+			&i.ID,
+			&i.DiagnosticCentreID,
+			&i.DayOfWeek,
+			&i.StartTime,
+			&i.EndTime,
+			&i.MaxAppointments,
+			&i.SlotDuration,
+			&i.BreakTime,
+			&i.CreatedAt,
+			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const update_Availability = `-- name: Update_Availability :one
 UPDATE diagnostic_centre_availability
 SET

--- a/adapters/db/querier.go
+++ b/adapters/db/querier.go
@@ -55,6 +55,7 @@ type Querier interface {
 	GetUserByEmail(ctx context.Context, email pgtype.Text) (*User, error)
 	GetUsers(ctx context.Context, arg GetUsersParams) ([]*User, error)
 	Get_Availability(ctx context.Context, arg Get_AvailabilityParams) ([]*DiagnosticCentreAvailability, error)
+	Get_Diagnostic_Availability(ctx context.Context, diagnosticCentreID string) ([]*DiagnosticCentreAvailability, error)
 	// Retrieves a single diagnostic record by its ID.
 	Get_Diagnostic_Centre(ctx context.Context, id string) (*DiagnosticCentre, error)
 	// GetDiagnosticCentreByManager

--- a/adapters/db/queries/availability.sql
+++ b/adapters/db/queries/availability.sql
@@ -36,6 +36,12 @@ ORDER BY
         WHEN 'sunday' THEN 7
     END;
 
+-- name: Get_Diagnostic_Availability :many
+SELECT * FROM diagnostic_centre_availability
+WHERE diagnostic_centre_id = $1
+ORDER BY created_at ASC;
+
+
 -- name: Update_Availability :one
 UPDATE diagnostic_centre_availability
 SET

--- a/adapters/db/repository/availability.repository.go
+++ b/adapters/db/repository/availability.repository.go
@@ -22,6 +22,10 @@ func (r *Repository) GetAvailability(ctx context.Context, params db.Get_Availabi
 	return r.database.Get_Availability(ctx, params)
 }
 
+func (r *Repository) GetDiagnosticAvailability(ctx context.Context, req string) ([]*db.DiagnosticCentreAvailability, error) {
+	return r.database.Get_Diagnostic_Availability(ctx, req)
+}
+
 func (r *Repository) UpdateAvailability(ctx context.Context, params db.Update_AvailabilityParams) (*db.DiagnosticCentreAvailability, error) {
 	return r.database.Update_Availability(ctx, params)
 }

--- a/adapters/handlers/availability.handler.go
+++ b/adapters/handlers/availability.handler.go
@@ -19,6 +19,7 @@ func (handler *HTTPHandler) CreateAvailability(context echo.Context) error {
 	return handler.service.CreateAvailability(context)
 }
 
+// GetAvailability retrieves availability slots for a diagnostic centre
 // @Summary Get availability for a diagnostic centre
 // @Description Get availability slots for the diagnostic centre, optionally filtered by day of week
 // @Tags Availability
@@ -32,7 +33,7 @@ func (handler *HTTPHandler) CreateAvailability(context echo.Context) error {
 // @Failure 404 {object} utils.ErrorResponse
 // @Router /api/v1/availability/{diagnostic_centre_id} [get]
 func (handler *HTTPHandler) GetAvailability(context echo.Context) error {
-	return nil
+	return handler.service.GetAvailability(context)
 }
 
 // @Summary Update availability for a diagnostic centre

--- a/core/domain/availability.domain.go
+++ b/core/domain/availability.domain.go
@@ -9,14 +9,16 @@ import (
 )
 
 type AvailabilitySlot struct {
-	ID                 uuid.UUID `json:"id"`
-	DiagnosticCentreID uuid.UUID `json:"diagnostic_centre_id"`
+	ID                 string `json:"id"`
+	DiagnosticCentreID string `json:"diagnostic_centre_id"`
 	DayOfWeek          string    `json:"day_of_week"`
-	StartTime          time.Time `json:"start_time"`
-	EndTime            time.Time `json:"end_time"`
-	MaxAppointments    int       `json:"max_appointments"`
-	SlotDuration       int32     `json:"slot_duration"` // minutes
-	BreakTime          int32     `json:"break_time"`    // minutes
+	StartTime          string    `json:"start_time"`
+	EndTime            string    `json:"end_time"`
+	MaxAppointments    int32       `json:"max_appointments"`
+	SlotDuration       string     `json:"slot_duration"` // minutes
+	BreakTime          string     `json:"break_time"`    // minutes
+	CreatedAt          string    `json:"created_at"`
+	UpdatedAt          string    `json:"updated_at"`
 }
 
 type Slots struct {
@@ -137,7 +139,7 @@ type GetAvailabilityDTO struct {
 // UpdateManyAvailabilitySlot represents a single slot in the update many request
 type UpdateManyAvailabilitySlot struct {
 	DiagnosticCentreID string     `json:"diagnostic_centre_id" validate:"required,uuid"`
-	DayOfWeek          string `json:"day_of_week" validate:"required"`
+	DayOfWeek          string     `json:"day_of_week" validate:"required"`
 	StartTime          *time.Time `json:"start_time,omitempty" validate:"omitempty,time"`
 	EndTime            *time.Time `json:"end_time,omitempty" validate:"omitempty,time"`
 	MaxAppointments    *int32     `json:"max_appointments,omitempty" validate:"omitempty,min=1"`

--- a/core/ports/availability.ports.go
+++ b/core/ports/availability.ports.go
@@ -9,6 +9,7 @@ import (
 // AvailabilityRepository defines the interface for availability data operations
 type AvailabilityRepository interface {
 	CreateAvailability(ctx context.Context, availability db.Create_AvailabilityParams) ([]*db.DiagnosticCentreAvailability, error)
+	GetDiagnosticAvailability(ctx context.Context, diagnostic_id string) ([]*db.DiagnosticCentreAvailability, error)
 	UpdateAvailability(ctx context.Context, update db.Update_AvailabilityParams) (*db.DiagnosticCentreAvailability, error)
 	GetAvailability(ctx context.Context, params db.Get_AvailabilityParams) ([]*db.DiagnosticCentreAvailability, error)
 	DeleteAvailability(ctx context.Context, req db.Delete_AvailabilityParams) error


### PR DESCRIPTION
This pull request introduces a new feature to retrieve availability slots for diagnostic centers, along with several supporting changes across the codebase. The changes include adding a new query, updating repository and service layers, and modifying the domain model to accommodate the new functionality.

### New Feature: Retrieve Diagnostic Center Availability
* Added a new SQL query `Get_Diagnostic_Availability` to fetch availability slots for a specific diagnostic center, ordered by creation date. (`adapters/db/availability.sql.go`, `adapters/db/queries/availability.sql`) [[1]](diffhunk://#diff-86fb1d67e5f9cd1485694c4ed5470a38d5a0dd6a708b22b1d096f439d1f82140R206-R242) [[2]](diffhunk://#diff-d0503d6055576c2e6a5d87ac35e72d72da9085b4a8463e7bbf6ab9e181264fb5R39-R44)
* Implemented a corresponding method `GetDiagnosticAvailability` in the repository layer to interact with the database using the new query. (`adapters/db/repository/availability.repository.go`)
* Updated the `Querier` interface to include the new method. (`adapters/db/querier.go`)

### Service and Handler Enhancements
* Added a service method `GetAvailability` to handle the retrieval of availability slots, with validation for input parameters and optional filtering by day of the week. (`core/services/availability.service.go`)
* Updated the HTTP handler to invoke the service method for the `GET /api/v1/availability/{diagnostic_centre_id}` endpoint. (`adapters/handlers/availability.handler.go`)

### Domain Model Adjustments
* Modified the `AvailabilitySlot` struct to use string types for fields like `StartTime`, `EndTime`, and `SlotDuration` to better align with the new feature's requirements. (`core/domain/availability.domain.go`)

### Port Updates
* Extended the `AvailabilityRepository` interface to include the new `GetDiagnosticAvailability` method. (`core/ports/availability.ports.go`)