### PR TITLE
Change medicue to medivue

### DIFF
--- a/main.go
+++ b/main.go
@@ -31,7 +31,7 @@ import (
 // @title Medicue
 // @version 1.0
 // @description Medicue API
-// @host medicue-api-production.up.railway.app
+// @host medivue-api-production.up.railway.app
 // @BasePath /v1
 func main() {
 	// Initialize logger with custom configuration


### PR DESCRIPTION
This pull request includes a minor change to the `main.go` file. The change updates the host URL in the API documentation comments to the correct domain.