### PR TITLE
Update swagger docs

### DIFF
--- a/swag.sh
+++ b/swag.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-swag init
+swag init -o swaggerdocs

--- a/swaggerdocs/docs.go
+++ b/swaggerdocs/docs.go
@@ -4790,7 +4790,7 @@ const docTemplate = `{
 // SwaggerInfo holds exported Swagger Info so clients can modify it
 var SwaggerInfo = &swag.Spec{
 	Version:          "1.0",
-	Host:             "medicue-api-production.up.railway.app",
+	Host:             "medivue-api-production.up.railway.app",
 	BasePath:         "/v1",
 	Schemes:          []string{},
 	Title:            "Medicue",

--- a/swaggerdocs/swagger.json
+++ b/swaggerdocs/swagger.json
@@ -6,7 +6,7 @@
         "contact": {},
         "version": "1.0"
     },
-    "host": "medicue-api-production.up.railway.app",
+    "host": "medivue-api-production.up.railway.app",
     "basePath": "/v1",
     "paths": {
         "/api/v1/availability": {

--- a/swaggerdocs/swagger.yaml
+++ b/swaggerdocs/swagger.yaml
@@ -968,7 +968,7 @@ definitions:
         example: "2025-06-27T12:00:00Z"
         type: string
     type: object
-host: medicue-api-production.up.railway.app
+host: medivue-api-production.up.railway.app
 info:
   contact: {}
   description: Medicue API


### PR DESCRIPTION
This pull request includes updates to the Swagger documentation configuration and fixes a typo in the host URL across multiple files. Additionally, it modifies the output directory for Swagger initialization.

### Swagger configuration updates:

* [`swag.sh`](diffhunk://#diff-22008618736706a0f85e5c6afbc8aaa2a328453cb3d05fd1808fd64f7baa48edL3-R3): Updated the `swag init` command to specify the output directory as `swaggerdocs`.

### Host URL typo fix:

* [`swaggerdocs/docs.go`](diffhunk://#diff-54d2b4056cc004375c737fc68fbc3b590b45af29b4f2ebc218729cc8b599e756L4793-R4793): Corrected the host URL from `medicue-api-production.up.railway.app` to `medivue-api-production.up.railway.app` in the `SwaggerInfo` definition.
* [`swaggerdocs/swagger.json`](diffhunk://#diff-3d0049b179c7cda61858510708e7b4fbe0737f48787503dd79891a9687615eb4L9-R9): Fixed the host URL typo in the Swagger JSON file.
* [`swaggerdocs/swagger.yaml`](diffhunk://#diff-39c97568541eab7488ee90d9f09e14bc2c5266336b4dde606f80938136a5938dL971-R971): Updated the host URL in the Swagger YAML file to reflect the corrected value.