### PR TITLE
Implement feedback

### DIFF
--- a/main.go
+++ b/main.go
@@ -32,7 +32,7 @@ import (
 // @version 1.0
 // @description Medicue API
 // @host medivue-api-production.up.railway.app
-// @BasePath /v1
+// @BasePath /
 func main() {
 	// Initialize logger with custom configuration
 	logConfig := utils.LogConfig{

--- a/swaggerdocs/docs.go
+++ b/swaggerdocs/docs.go
@@ -4516,9 +4516,6 @@ const docTemplate = `{
                     "maxLength": 20,
                     "minLength": 6
                 },
-                "diagnostic_Centre": {
-                    "type": "string"
-                },
                 "email": {
                     "type": "string"
                 },
@@ -4791,7 +4788,7 @@ const docTemplate = `{
 var SwaggerInfo = &swag.Spec{
 	Version:          "1.0",
 	Host:             "medivue-api-production.up.railway.app",
-	BasePath:         "/v1",
+	BasePath:         "/",
 	Schemes:          []string{},
 	Title:            "Medicue",
 	Description:      "Medicue API",

--- a/swaggerdocs/swagger.json
+++ b/swaggerdocs/swagger.json
@@ -7,7 +7,7 @@
         "version": "1.0"
     },
     "host": "medivue-api-production.up.railway.app",
-    "basePath": "/v1",
+    "basePath": "/",
     "paths": {
         "/api/v1/availability": {
             "post": {
@@ -4509,9 +4509,6 @@
                     "type": "string",
                     "maxLength": 20,
                     "minLength": 6
-                },
-                "diagnostic_Centre": {
-                    "type": "string"
                 },
                 "email": {
                     "type": "string"

--- a/swaggerdocs/swagger.yaml
+++ b/swaggerdocs/swagger.yaml
@@ -1,4 +1,4 @@
-basePath: /v1
+basePath: /
 definitions:
   db.Doctor:
     enum:
@@ -767,8 +767,6 @@ definitions:
       confirm_password:
         maxLength: 20
         minLength: 6
-        type: string
-      diagnostic_Centre:
         type: string
       email:
         type: string


### PR DESCRIPTION
This pull request includes changes to the Medicue API's Swagger documentation and configuration files to update the base path and remove the `diagnostic_Centre` field from the API schema. These updates ensure consistency across documentation and simplify the API schema.

### Updates to Swagger documentation:

* [`swaggerdocs/swagger.json`](diffhunk://#diff-3d0049b179c7cda61858510708e7b4fbe0737f48787503dd79891a9687615eb4L10-R10): Changed `basePath` from `/v1` to `/` to align with the updated API structure. [[1]](diffhunk://#diff-3d0049b179c7cda61858510708e7b4fbe0737f48787503dd79891a9687615eb4L10-R10) [[2]](diffhunk://#diff-3d0049b179c7cda61858510708e7b4fbe0737f48787503dd79891a9687615eb4L4513-L4515)
* [`swaggerdocs/swagger.yaml`](diffhunk://#diff-39c97568541eab7488ee90d9f09e14bc2c5266336b4dde606f80938136a5938dL1-R1): Updated `basePath` from `/v1` to `/` for consistency with other documentation files.

### Schema simplification:

* [`swaggerdocs/docs.go`](diffhunk://#diff-54d2b4056cc004375c737fc68fbc3b590b45af29b4f2ebc218729cc8b599e756L4519-L4521): Removed the `diagnostic_Centre` field from the API schema definition in `docTemplate`. [[1]](diffhunk://#diff-54d2b4056cc004375c737fc68fbc3b590b45af29b4f2ebc218729cc8b599e756L4519-L4521) [[2]](diffhunk://#diff-54d2b4056cc004375c737fc68fbc3b590b45af29b4f2ebc218729cc8b599e756L4794-R4791)
* [`swaggerdocs/swagger.yaml`](diffhunk://#diff-39c97568541eab7488ee90d9f09e14bc2c5266336b4dde606f80938136a5938dL771-L772): Removed the `diagnostic_Centre` field from the schema definitions. 

### Configuration updates:

* [`main.go`](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261L35-R35): Updated the `BasePath` from `/v1` to `/` in the API configuration to reflect the new base path.