### PR TITLE
Ai integrate

### DIFF
--- a/core/domain/user.domain.go
+++ b/core/domain/user.domain.go
@@ -27,11 +27,10 @@ type (
 	}
 
 	UserRegisterDTO struct {
-		Email            string      `json:"email" validate:"email,required"`
-		Password         string      `json:"password" validate:"gte=6,lte=20,required"`
-		ConfirmPassword  string      `json:"confirm_password" validate:"eqfield=Password,gte=6,lte=20,required"`
-		UserType         db.UserEnum `json:"user_type" validate:"required,oneof=USER DIAGNOSTIC_CENTRE_OWNER"`
-		PhoneNumber      string      `json:"phone_number" validate:"omitempty,e164"`
+		Email           string      `json:"email" validate:"email,required"`
+		Password        string      `json:"password" validate:"gte=6,lte=20,required"`
+		ConfirmPassword string      `json:"confirm_password" validate:"eqfield=Password,gte=6,lte=20,required"`
+		UserType        db.UserEnum `json:"user_type" validate:"required,oneof=USER DIAGNOSTIC_CENTRE_OWNER"`
 	}
 	DiagnosticCentreManagerRegisterDTO struct {
 		Email    string      `json:"email" validate:"email,required"`
@@ -128,9 +127,6 @@ func BuildNewUser(user UserRegisterDTO) (db.CreateUserParams, error) {
 		Email:    pgtype.Text{String: user.Email, Valid: true},
 		Password: password,
 		UserType: user.UserType,
-	}
-	if user.PhoneNumber != "" {
-		params.PhoneNumber = pgtype.Text{String: user.PhoneNumber, Valid: true}
 	}
 	return params, nil
 }

--- a/core/services/user.service.go
+++ b/core/services/user.service.go
@@ -35,7 +35,7 @@ func (service *ServicesHandler) Create(context echo.Context) error {
 	createdUser, err := service.createUserHelper(
 		context, newUser, db.UserEnumDIAGNOSTICCENTREOWNER, db.UserEnumUSER)
 	if err != nil {
-		return err
+		return utils.ErrorResponse(http.StatusConflict, err, context)
 	}
 
 	// Generate verification token

--- a/swaggerdocs/docs.go
+++ b/swaggerdocs/docs.go
@@ -4524,9 +4524,6 @@ const docTemplate = `{
                     "maxLength": 20,
                     "minLength": 6
                 },
-                "phone_number": {
-                    "type": "string"
-                },
                 "user_type": {
                     "enum": [
                         "USER",

--- a/swaggerdocs/swagger.json
+++ b/swaggerdocs/swagger.json
@@ -4518,9 +4518,6 @@
                     "maxLength": 20,
                     "minLength": 6
                 },
-                "phone_number": {
-                    "type": "string"
-                },
                 "user_type": {
                     "enum": [
                         "USER",

--- a/swaggerdocs/swagger.yaml
+++ b/swaggerdocs/swagger.yaml
@@ -774,8 +774,6 @@ definitions:
         maxLength: 20
         minLength: 6
         type: string
-      phone_number:
-        type: string
       user_type:
         allOf:
         - $ref: '#/definitions/db.UserEnum'


### PR DESCRIPTION
This pull request removes support for the `phone_number` field across the codebase, simplifies error handling in user creation, and updates documentation files accordingly. The most important changes include the removal of the `phone_number` field from user-related DTOs and database parameters, the adjustment of error handling in the user creation service, and updates to Swagger documentation files to reflect the removal of the `phone_number` field.

### Removal of `phone_number` field:
* [`core/domain/user.domain.go`](diffhunk://#diff-238df9fdb7ee923074076086d681f3f9ad9ae2d3ac55ffae2516d4132ce3705bL34): Removed the `phone_number` field from the `UserRegisterDTO` struct and its associated validation rules. Also removed the logic for setting the `PhoneNumber` field in the `BuildNewUser` function. [[1]](diffhunk://#diff-238df9fdb7ee923074076086d681f3f9ad9ae2d3ac55ffae2516d4132ce3705bL34) [[2]](diffhunk://#diff-238df9fdb7ee923074076086d681f3f9ad9ae2d3ac55ffae2516d4132ce3705bL132-L134)

### Error handling improvements:
* [`core/services/user.service.go`](diffhunk://#diff-86ad74e50ca7f2868e6430ad8763e2e780df81c7ea02ac1af331765612b8748bL38-R38): Updated the `Create` method to return a structured error response using `utils.ErrorResponse` instead of directly returning the error.

### Documentation updates:
* `swaggerdocs/docs.go`, `swaggerdocs/swagger.json`, `swaggerdocs/swagger.yaml`: Removed references to the `phone_number` field from Swagger documentation files, including JSON, YAML, and Go templates, ensuring the documentation aligns with the updated codebase. [[1]](diffhunk://#diff-54d2b4056cc004375c737fc68fbc3b590b45af29b4f2ebc218729cc8b599e756L4527-L4529) [[2]](diffhunk://#diff-3d0049b179c7cda61858510708e7b4fbe0737f48787503dd79891a9687615eb4L4521-L4523) [[3]](diffhunk://#diff-39c97568541eab7488ee90d9f09e14bc2c5266336b4dde606f80938136a5938dL777-L778)