### PR TITLE
Add token

### DIFF
--- a/adapters/db/diagnostic.centre.sql.go
+++ b/adapters/db/diagnostic.centre.sql.go
@@ -323,6 +323,75 @@ func (q *Queries) GetAdminHistory(ctx context.Context, id string) ([]*GetAdminHi
 	return items, nil
 }
 
+const getDiagnosticCentreWithPrices = `-- name: GetDiagnosticCentreWithPrices :one
+SELECT
+  dc.id, dc.diagnostic_centre_name, dc.latitude, dc.longitude, dc.address, dc.contact, dc.doctors, dc.available_tests, dc.created_by, dc.admin_id, dc.created_at, dc.updated_at, dc.admin_assigned_at, dc.admin_assigned_by, dc.admin_unassigned_at, dc.admin_unassigned_by, dc.admin_status,
+  COALESCE(prices.test_prices, '[]'::jsonb) AS test_prices
+FROM diagnostic_centres dc
+LEFT JOIN diagnostic_centre_test_prices dctp
+  ON dctp.diagnostic_centre_id = dc.id
+LEFT JOIN LATERAL (
+  SELECT jsonb_agg(
+    jsonb_build_object(
+      'test_type', dctp.test_type,
+      'price', dctp.price
+    )
+  ) AS test_prices
+  FROM diagnostic_centre_test_prices dctp
+  WHERE dctp.diagnostic_centre_id = dc.id
+) prices ON true
+WHERE dc.id = $1
+GROUP BY dc.id, prices.test_prices
+`
+
+type GetDiagnosticCentreWithPricesRow struct {
+	ID                   string             `db:"id" json:"id"`
+	DiagnosticCentreName string             `db:"diagnostic_centre_name" json:"diagnostic_centre_name"`
+	Latitude             pgtype.Float8      `db:"latitude" json:"latitude"`
+	Longitude            pgtype.Float8      `db:"longitude" json:"longitude"`
+	Address              []byte             `db:"address" json:"address"`
+	Contact              []byte             `db:"contact" json:"contact"`
+	Doctors              []string           `db:"doctors" json:"doctors"`
+	AvailableTests       []string           `db:"available_tests" json:"available_tests"`
+	CreatedBy            string             `db:"created_by" json:"created_by"`
+	AdminID              pgtype.UUID        `db:"admin_id" json:"admin_id"`
+	CreatedAt            pgtype.Timestamptz `db:"created_at" json:"created_at"`
+	UpdatedAt            pgtype.Timestamptz `db:"updated_at" json:"updated_at"`
+	AdminAssignedAt      pgtype.Timestamptz `db:"admin_assigned_at" json:"admin_assigned_at"`
+	AdminAssignedBy      pgtype.UUID        `db:"admin_assigned_by" json:"admin_assigned_by"`
+	AdminUnassignedAt    pgtype.Timestamptz `db:"admin_unassigned_at" json:"admin_unassigned_at"`
+	AdminUnassignedBy    pgtype.UUID        `db:"admin_unassigned_by" json:"admin_unassigned_by"`
+	AdminStatus          pgtype.Text        `db:"admin_status" json:"admin_status"`
+	TestPrices           []byte             `db:"test_prices" json:"test_prices"`
+}
+
+// Get Centre With Pricess
+func (q *Queries) GetDiagnosticCentreWithPrices(ctx context.Context, id string) (*GetDiagnosticCentreWithPricesRow, error) {
+	row := q.db.QueryRow(ctx, getDiagnosticCentreWithPrices, id)
+	var i GetDiagnosticCentreWithPricesRow
+	err := row.Scan(
+		&i.ID,
+		&i.DiagnosticCentreName,
+		&i.Latitude,
+		&i.Longitude,
+		&i.Address,
+		&i.Contact,
+		&i.Doctors,
+		&i.AvailableTests,
+		&i.CreatedBy,
+		&i.AdminID,
+		&i.CreatedAt,
+		&i.UpdatedAt,
+		&i.AdminAssignedAt,
+		&i.AdminAssignedBy,
+		&i.AdminUnassignedAt,
+		&i.AdminUnassignedBy,
+		&i.AdminStatus,
+		&i.TestPrices,
+	)
+	return &i, err
+}
+
 const get_Diagnostic_Centre = `-- name: Get_Diagnostic_Centre :one
 SELECT 
   dc.id, dc.diagnostic_centre_name, dc.latitude, dc.longitude, dc.address, dc.contact, dc.doctors, dc.available_tests, dc.created_by, dc.admin_id, dc.created_at, dc.updated_at, dc.admin_assigned_at, dc.admin_assigned_by, dc.admin_unassigned_at, dc.admin_unassigned_by, dc.admin_status,
@@ -1400,14 +1469,8 @@ SET
   contact = COALESCE($7, contact),
   doctors = COALESCE($8, doctors),
   available_tests = COALESCE($9, available_tests),
-  admin_id = CASE 
-    WHEN $10 IS NULL THEN NULL 
-    ELSE COALESCE($10, admin_id)
-  END,
-  admin_assigned_by = CASE
-    WHEN $10 IS NULL THEN NULL -- If admin_id is null, also null the assigned_by
-    ELSE COALESCE($11, admin_assigned_by)
-  END,
+  admin_id = $10,
+  admin_assigned_by = $11,
   updated_at = NOW()
 WHERE id = $1 AND created_by = $2
 RETURNING id, diagnostic_centre_name, latitude, longitude, address, contact, doctors, available_tests, created_by, admin_id, created_at, updated_at, admin_assigned_at, admin_assigned_by, admin_unassigned_at, admin_unassigned_by, admin_status

--- a/adapters/db/querier.go
+++ b/adapters/db/querier.go
@@ -38,6 +38,8 @@ type Querier interface {
 	GetAdminHistory(ctx context.Context, id string) ([]*GetAdminHistoryRow, error)
 	GetAppointment(ctx context.Context, id string) (*Appointment, error)
 	GetCentreAppointments(ctx context.Context, arg GetCentreAppointmentsParams) ([]*GetCentreAppointmentsRow, error)
+	// Get Centre With Pricess
+	GetDiagnosticCentreWithPrices(ctx context.Context, id string) (*GetDiagnosticCentreWithPricesRow, error)
 	GetEmailVerificationToken(ctx context.Context, token string) (*EmailVerificationToken, error)
 	// Get a Medical Record
 	GetMedicalRecord(ctx context.Context, arg GetMedicalRecordParams) (*GetMedicalRecordRow, error)

--- a/adapters/db/queries/diagnostic.centre.sql
+++ b/adapters/db/queries/diagnostic.centre.sql
@@ -123,17 +123,32 @@ SET
   contact = COALESCE($7, contact),
   doctors = COALESCE($8, doctors),
   available_tests = COALESCE($9, available_tests),
-  admin_id = CASE 
-    WHEN $10 IS NULL THEN NULL 
-    ELSE COALESCE($10, admin_id)
-  END,
-  admin_assigned_by = CASE
-    WHEN $10 IS NULL THEN NULL -- If admin_id is null, also null the assigned_by
-    ELSE COALESCE($11, admin_assigned_by)
-  END,
+  admin_id = $10,
+  admin_assigned_by = $11,
   updated_at = NOW()
 WHERE id = $1 AND created_by = $2
 RETURNING *;
+
+-- Get Centre With Pricess
+-- name: GetDiagnosticCentreWithPrices :one
+SELECT
+  dc.*,
+  COALESCE(prices.test_prices, '[]'::jsonb) AS test_prices
+FROM diagnostic_centres dc
+LEFT JOIN diagnostic_centre_test_prices dctp
+  ON dctp.diagnostic_centre_id = dc.id
+LEFT JOIN LATERAL (
+  SELECT jsonb_agg(
+    jsonb_build_object(
+      'test_type', dctp.test_type,
+      'price', dctp.price
+    )
+  ) AS test_prices
+  FROM diagnostic_centre_test_prices dctp
+  WHERE dctp.diagnostic_centre_id = dc.id
+) prices ON true
+WHERE dc.id = $1
+GROUP BY dc.id, prices.test_prices;
 
 -- Deletes a diagnosticCentre only by the created_by.
 -- name: Delete_Diagnostic_Centre_ByOwner :one

--- a/adapters/db/queries/test_price.sql
+++ b/adapters/db/queries/test_price.sql
@@ -15,4 +15,9 @@ INSERT INTO diagnostic_centre_test_prices (
     is_active
 ) 
 SELECT * FROM test_price_params
+ON CONFLICT (diagnostic_centre_id, test_type)
+DO UPDATE SET
+    price = EXCLUDED.price,
+    currency = EXCLUDED.currency,
+    is_active = EXCLUDED.is_active
 RETURNING *;

--- a/adapters/db/repository/diagnostic.repository.go
+++ b/adapters/db/repository/diagnostic.repository.go
@@ -39,6 +39,13 @@ func (repo *Repository) GetDiagnosticCentre(
 	return repo.database.Get_Diagnostic_Centre(ctx, arg)
 }
 
+func (repo *Repository) GetDiagnosticWithPrices(
+	ctx context.Context,
+	arg string,
+) (*db.GetDiagnosticCentreWithPricesRow, error) {
+	return repo.database.GetDiagnosticCentreWithPrices(ctx, arg)
+}
+
 func (repo *Repository) GetDiagnosticCentreByManager(
 	ctx context.Context,
 	arg db.Get_Diagnostic_Centre_ByManagerParams,

--- a/adapters/db/test_price.sql.go
+++ b/adapters/db/test_price.sql.go
@@ -26,6 +26,11 @@ INSERT INTO diagnostic_centre_test_prices (
     is_active
 ) 
 SELECT diagnostic_centre_id, test_type, price, currency, is_active FROM test_price_params
+ON CONFLICT (diagnostic_centre_id, test_type)
+DO UPDATE SET
+    price = EXCLUDED.price,
+    currency = EXCLUDED.currency,
+    is_active = EXCLUDED.is_active
 RETURNING id, diagnostic_centre_id, test_type, price, currency, is_active, created_at, updated_at
 `
 

--- a/adapters/routes/diagnostic.go
+++ b/adapters/routes/diagnostic.go
@@ -34,7 +34,7 @@ func DiagnosticRoutes(group *echo.Group, handler *handlers.HTTPHandler) {
 			factory: func() interface{} {
 				return &domain.PaginationQueryDTO{}
 			},
-			description: "Get Diagnostic Centre Manager",
+			description: "Get Diagnostic Centre Managers",
 		},
 		{
 			method:  http.MethodPost,

--- a/core/domain/diagnostic.domain.go
+++ b/core/domain/diagnostic.domain.go
@@ -62,15 +62,15 @@ type (
 		DiagnosticCentreID uuid.UUID `param:"diagnostic_centre_id"`
 	}
 	UpdateDiagnosticBodyDTO struct {
-		DiagnosticCentreName string    `json:"diagnostic_centre_name"`
-		Latitude             float64   `json:"latitude"`
-		Longitude            float64   `json:"longitude"`
-		Address              Address   `json:"address"`
-		Contact              Contact   `json:"contact"`
-		Doctors              []string  `json:"doctors"`
-		AvailableTests       []string  `json:"available_tests"`
-		CreatedBy            uuid.UUID `json:"created_by"`
-		ADMINID              uuid.UUID `json:"admin_id"`
+		DiagnosticCentreName string       `json:"diagnostic_centre_name"`
+		Latitude             float64      `json:"latitude"`
+		Longitude            float64      `json:"longitude"`
+		Address              Address      `json:"address"`
+		Contact              Contact      `json:"contact"`
+		Doctors              []string     `json:"doctors"`
+		AvailableTests       []TestPrices `json:"available_tests"`
+		CreatedBy            uuid.UUID    `json:"created_by"`
+		ADMINID              uuid.UUID    `json:"admin_id"`
 	}
 	UpdateDiagnosticManagerDTO struct {
 		ID        uuid.UUID `json:"diagnostic_centre_id" validate:"uuid,required"`
@@ -80,10 +80,10 @@ type (
 		ID uuid.UUID `json:"diagnostic_centre_id" validate:"uuid,required"`
 	}
 	GetDiagnosticRecordsParamDTO struct {
-		DiagnosticCentreID string    `param:"diagnostic_centre_id" validate:"required,uuid"`
+		DiagnosticCentreID string `param:"diagnostic_centre_id" validate:"required,uuid"`
 		StartDate          string `query:"start_date" validate:"omitempty,datetime=2006-01-02"`
 		EndDate            string `query:"end_date" validate:"omitempty,datetime=2006-01-02"`
-		DocumentType       string    `query:"document_type" validate:"omitempty,oneof=LAB_REPORT PRESCRIPTION IMAGING DISCHARGE_SUMMARY OTHER"`
+		DocumentType       string `query:"document_type" validate:"omitempty,oneof=LAB_REPORT PRESCRIPTION IMAGING DISCHARGE_SUMMARY OTHER"`
 		PaginationQueryDTO
 	}
 	PaginationQueryDTO struct {

--- a/core/domain/payment.domain.go
+++ b/core/domain/payment.domain.go
@@ -8,16 +8,16 @@ import (
 
 const (
 	PaymentMethodCard     PaymentMethod = "card"
-	PaymentMethodTransfer PaymentMethod = "transfer"
 	PaymentMethodCash     PaymentMethod = "cash"
 	PaymentMethodWallet   PaymentMethod = "wallet"
+	PaymentMethodTransfer PaymentMethod = "transfer"
 )
 
 const (
-	PaymentProviderPaystack    PaymentProvider = "PAYSTACK"
-	PaymentProviderFlutterwave PaymentProvider = "FLUTTERWAVE"
 	PaymentProviderStripe      PaymentProvider = "STRIPE"
 	PaymentProviderMonnify     PaymentProvider = "MONNIFY"
+	PaymentProviderPaystack    PaymentProvider = "PAYSTACK"
+	PaymentProviderFlutterwave PaymentProvider = "FLUTTERWAVE"
 )
 
 type (

--- a/core/ports/diagnostic.ports.go
+++ b/core/ports/diagnostic.ports.go
@@ -23,6 +23,11 @@ type DiagnosticRepository interface {
 		id string,
 	) (*db.Get_Diagnostic_CentreRow, error)
 
+	GetDiagnosticWithPrices(
+		ctx context.Context,
+		id string,
+	) (*db.GetDiagnosticCentreWithPricesRow, error)
+
 	UpdateDiagnosticCentreByOwner(
 		ctx context.Context,
 		params db.Update_Diagnostic_Centre_ByOwnerParams,

--- a/core/services/diagnostic.service.go
+++ b/core/services/diagnostic.service.go
@@ -24,6 +24,8 @@ func (service *ServicesHandler) CreateDiagnosticCentre(context echo.Context) err
 		return echo.NewHTTPError(http.StatusUnauthorized, utils.AuthenticationRequired)
 	}
 
+	ctx := context.Request().Context()
+
 	// This validated at the middleware level
 	dto, _ := context.Get(utils.ValidatedBodyDTO).(*domain.CreateDiagnosticDTO)
 
@@ -39,18 +41,17 @@ func (service *ServicesHandler) CreateDiagnosticCentre(context echo.Context) err
 	params.CreatedBy = currentUser.UserID.String()
 
 	// Start transaction
-	tx, err := service.diagnosticPort.BeginDiagnostic(context.Request().Context())
+	tx, err := service.diagnosticPort.BeginDiagnostic(ctx)
 	if err != nil {
 		utils.Error("Failed to start diagnostic transaction",
 			utils.LogField{Key: "error", Value: err.Error()})
 		return utils.ErrorResponse(http.StatusInternalServerError, err, context)
 	}
-	defer tx.Rollback(context.Request().Context())
+	defer tx.Rollback(ctx)
 
 	// Make this a transaction
 	// Create diagnostic centre
-	diagnostic_centre, err := tx.CreateDiagnosticCentre(
-		context.Request().Context(), *params)
+	diagnostic_centre, err := tx.CreateDiagnosticCentre(ctx, *params)
 	if err != nil {
 		utils.Error("Failed to create diagnostic centre",
 			utils.LogField{Key: "error", Value: err.Error()},
@@ -80,7 +81,7 @@ func (service *ServicesHandler) CreateDiagnosticCentre(context echo.Context) err
 			utils.LogField{Key: "error", Value: err.Error()})
 		return utils.ErrorResponse(http.StatusBadRequest, err, context)
 	}
-	test_price, err := tx.CreateTestPrice(context.Request().Context(), *buildPrice)
+	test_price, err := tx.CreateTestPrice(ctx, *buildPrice)
 	if err != nil {
 		utils.Error("Failed to submit test price",
 			utils.LogField{Key: "error", Value: err.Error()},
@@ -109,7 +110,7 @@ func (service *ServicesHandler) CreateDiagnosticCentre(context echo.Context) err
 	}
 
 	// Commit transaction
-	if err := tx.Commit(context.Request().Context()); err != nil {
+	if err := tx.Commit(ctx); err != nil {
 		utils.Error("Failed to commit diagnostic transaction",
 			utils.LogField{Key: "error", Value: err.Error()})
 		return utils.ErrorResponse(http.StatusInternalServerError, errors.New("failed to commit transaction"), context)
@@ -352,16 +353,67 @@ func (service *ServicesHandler) UpdateDiagnosticCentre(context echo.Context) err
 	if err != nil {
 		return utils.ErrorResponse(http.StatusBadRequest, err, context)
 	}
+
 	dto.ID = param_id
 	dto.CreatedBy = currentUser.UserID.String()
 	if body.ADMINID != uuid.Nil {
 		dto.AdminAssignedBy = pgtype.UUID{Bytes: currentUser.UserID, Valid: true}
 	}
-	response, err := service.diagnosticPort.UpdateDiagnosticCentreByOwner(context.Request().Context(), *dto)
+
+	ctx := context.Request().Context()
+
+	// Implement test Price here
+	buildPrice, err := buildTestPrice(&domain.CreateDiagnosticDTO{
+		DiagnosticCentreName: dto.DiagnosticCentreName,
+		Latitude:             dto.Latitude.Float64,
+		Longitude:            dto.Longitude.Float64,
+		Address:              body.Address,
+		Contact:              body.Contact,
+		AvailableTests:       body.AvailableTests,
+	}, dto.ID)
+	if err != nil {
+		utils.Error("Failed to build test prices",
+			utils.LogField{Key: "error", Value: err.Error()})
+		return utils.ErrorResponse(http.StatusBadRequest, err, context)
+	}
+
+	_, err = service.testPricePort.CreateTestPrice(ctx, *buildPrice)
+	if err != nil {
+		utils.Error("Failed to submit test price",
+			utils.LogField{Key: "error", Value: err.Error()},
+			utils.LogField{Key: "admin_id", Value: dto.AdminID})
+		return utils.ErrorResponse(http.StatusBadRequest, err, context)
+	}
+
+	response, err := service.diagnosticPort.UpdateDiagnosticCentreByOwner(ctx, *dto)
 	if err != nil {
 		return utils.ErrorResponse(http.StatusNotAcceptable, err, context)
 	}
-	return utils.ResponseMessage(http.StatusNoContent, response, context)
+
+	resp, err := service.diagnosticPort.GetDiagnosticWithPrices(ctx, response.ID)
+
+	row := &db.List_Diagnostic_Centres_ByOwnerRow{
+		ID: resp.ID,
+		DiagnosticCentreName: resp.DiagnosticCentreName,
+		Latitude: resp.Latitude,
+		Longitude: resp.Longitude,
+		Address: resp.Address,
+		Contact: resp.Contact,
+		Doctors: resp.Doctors,
+		AvailableTests: resp.AvailableTests,
+		CreatedAt: resp.CreatedAt,
+		UpdatedAt: resp.UpdatedAt,
+		AdminID: resp.AdminID,
+		TestPrices: resp.TestPrices,
+		AdminAssignedAt: resp.AdminAssignedAt,
+		AdminStatus: resp.AdminStatus,
+	}
+	// Build response
+	res, err := buildDiagnosticCentreResponseFromRow(row)
+	if err != nil {
+		return utils.ErrorResponse(http.StatusInternalServerError, err, context)
+	}
+	return utils.ResponseMessage(http.StatusAccepted, res, context)
 }
 
 // DeleteDiagnosticCentre deletes a diagnostic center (owner only)

--- a/core/services/utils.services.go
+++ b/core/services/utils.services.go
@@ -212,7 +212,10 @@ func buildUpdateDiagnosticCentreByOwnerParams(value *domain.UpdateDiagnosticBody
 	copy(doctors, value.Doctors)
 
 	availableTests := make([]string, len(value.AvailableTests))
-	copy(availableTests, value.AvailableTests)
+
+	for i, v := range value.AvailableTests {
+		availableTests[i] = v.TestType
+	}
 
 	var adminID pgtype.UUID
 	if value.ADMINID != uuid.Nil {


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Upsert diagnostic test prices and fetch centres with aggregated prices
<code>✨ Enhancement</code> <code>🕐 40+ Minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>Description</summary>

<br/>

<pre>
• Add a DB query to fetch a diagnostic centre with aggregated test prices.
• Upsert test prices on create/update and return the updated centre payload.
• Update diagnostic update DTO to accept test prices and map them to centre metadata.
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
  C[Client] --> API["Diagnostic HTTP API"] --> S["DiagnosticService"] --> D["DiagnosticRepo (sqlc)"] --> PG[(Postgres)]
  S --> TP["TestPriceRepo (sqlc)"] --> PG
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The following are alternative approaches to this PR:

<details>
<summary><b>1. Wrap update + price upsert in a single DB transaction</b></summary>

- ➕ Prevents partial updates (prices updated but centre update fails, or vice versa)
- ➕ Keeps read-after-write consistency when immediately returning the updated centre
- ➖ Requires adding a transaction wrapper/tx port similar to CreateDiagnosticCentre
- ➖ Slightly more plumbing across service/ports/repo

</details>

<details>
<summary><b>2. Single SQL statement using CTE to upsert prices and return centre+prices</b></summary>

- ➕ Atomic at the DB level with a single round-trip
- ➕ Can return the final aggregated response directly
- ➖ More complex SQL and harder to maintain with sqlc
- ➖ Less reusable for other code paths

</details>

**Recommendation:** Prefer the transaction approach for UpdateDiagnosticCentre (matching the existing create flow): perform price upsert and centre update in one tx, then fetch/return centre+prices. This keeps the current layered design while eliminating inconsistent intermediate states.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Enhancement</strong> (10)</summary>

<blockquote>
<details>
<summary><strong>diagnostic.centre.sql.go</strong> <code>Add sqlc query to fetch centre with aggregated test prices</code> <code>+71/-8</code></summary>

<br/>

>Add sqlc query to fetch centre with aggregated test prices
>
><pre>
>• Introduces GetDiagnosticCentreWithPrices (SQL + row type + scan method) to return a diagnostic centre plus a JSONB-aggregated list of test prices. Simplifies owner update SQL to assign admin_id/admin_assigned_by directly (no CASE wrappers).
></pre>
>
><a href='https://github.com/QUDUSKUNLE/engine/pull/67/files#diff-8d0be3760e8416bfe38337847fdeb0c417b73de2869cecb43faeaf8eaa189b6c'>adapters/db/diagnostic.centre.sql.go</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>querier.go</strong> <code>Expose GetDiagnosticCentreWithPrices in the sqlc Querier interface</code> <code>+2/-0</code></summary>

<br/>

>Expose GetDiagnosticCentreWithPrices in the sqlc Querier interface
>
><pre>
>• Adds the GetDiagnosticCentreWithPrices method to the generated Querier contract so repositories/services can call the new query.
></pre>
>
><a href='https://github.com/QUDUSKUNLE/engine/pull/67/files#diff-e05b033eaf6d0bacadc6ef10c04734d14e0d413bb940f13216cdc45e1c57aee9'>adapters/db/querier.go</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>diagnostic.centre.sql</strong> <code>Add GetDiagnosticCentreWithPrices query and simplify owner update SQL</code> <code>+23/-8</code></summary>

<br/>

>Add GetDiagnosticCentreWithPrices query and simplify owner update SQL
>
><pre>
>• Defines a new GetDiagnosticCentreWithPrices :one query that returns dc.* plus aggregated test_prices. Updates Update_Diagnostic_Centre_ByOwner to set admin_id/admin_assigned_by via parameters directly.
></pre>
>
><a href='https://github.com/QUDUSKUNLE/engine/pull/67/files#diff-375bc427cc9a8e01d51c23451484e3606a23ad4a09da008629e7f9256b1ea260'>adapters/db/queries/diagnostic.centre.sql</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>test_price.sql</strong> <code>Make test price writes idempotent via ON CONFLICT upsert</code> <code>+5/-0</code></summary>

<br/>

>Make test price writes idempotent via ON CONFLICT upsert
>
><pre>
>• Extends the bulk insert into diagnostic_centre_test_prices to upsert by (diagnostic_centre_id, test_type), updating price/currency/is_active when a row already exists.
></pre>
>
><a href='https://github.com/QUDUSKUNLE/engine/pull/67/files#diff-29336017434ea669891714c340eb6da4f7d9912d7a50ebaac4bd5ce0a6334bec'>adapters/db/queries/test_price.sql</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>diagnostic.repository.go</strong> <code>Add repository method to fetch centre with prices</code> <code>+7/-0</code></summary>

<br/>

>Add repository method to fetch centre with prices
>
><pre>
>• Adds GetDiagnosticWithPrices to the repository, delegating to the new sqlc query for centre + aggregated prices.
></pre>
>
><a href='https://github.com/QUDUSKUNLE/engine/pull/67/files#diff-aadc3956c3048233613821f83736d65daf92a04c3ffaade54390b02f8c55640e'>adapters/db/repository/diagnostic.repository.go</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>test_price.sql.go</strong> <code>Regenerate sqlc code for test price upsert</code> <code>+5/-0</code></summary>

<br/>

>Regenerate sqlc code for test price upsert
>
><pre>
>• Updates generated Go SQL to include ON CONFLICT upsert behavior for test prices, matching adapters/db/queries/test_price.sql.
></pre>
>
><a href='https://github.com/QUDUSKUNLE/engine/pull/67/files#diff-f804742d18fe8c8057afee1a14e8bff420d68b42fdb7dc1dac391affb8e748a9'>adapters/db/test_price.sql.go</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>diagnostic.domain.go</strong> <code>Change update DTO to accept test prices (type+price)</code> <code>+11/-11</code></summary>

<br/>

>Change update DTO to accept test prices (type+price)
>
><pre>
>• Updates UpdateDiagnosticBodyDTO.AvailableTests from []string to []TestPrices to carry pricing data during updates. Minor formatting-only adjustments to DTO field alignment.
></pre>
>
><a href='https://github.com/QUDUSKUNLE/engine/pull/67/files#diff-dae4ea400ecc62594cf8522e060b53a231c1c3901979acc4aae990c086e87fe7'>core/domain/diagnostic.domain.go</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>diagnostic.ports.go</strong> <code>Add port method for fetching centre with prices</code> <code>+5/-0</code></summary>

<br/>

>Add port method for fetching centre with prices
>
><pre>
>• Extends the DiagnosticRepository interface with GetDiagnosticWithPrices so services can retrieve the enriched centre view after updates.
></pre>
>
><a href='https://github.com/QUDUSKUNLE/engine/pull/67/files#diff-6259659aa436a3c53d6fa63e162a990ff742b33e816e1263da5ef6bd6119f22b'>core/ports/diagnostic.ports.go</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>diagnostic.service.go</strong> <code>Upsert test prices on update and return centre payload with prices</code> <code>+60/-8</code></summary>

<br/>

>Upsert test prices on update and return centre payload with prices
>
><pre>
>• Uses a shared request context variable for create flow and threads it through tx calls. UpdateDiagnosticCentre now builds test price inputs from the update body, upserts prices, updates the centre, then fetches and returns the centre with aggregated test_prices (HTTP 202) instead of a no-content response.
></pre>
>
><a href='https://github.com/QUDUSKUNLE/engine/pull/67/files#diff-25a042aa8680361216dd2e959f2e6dc0a6ffa8dca658d1281ce767313963db32'>core/services/diagnostic.service.go</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>utils.services.go</strong> <code>Map update DTO test prices to available test types</code> <code>+4/-1</code></summary>

<br/>

>Map update DTO test prices to available test types
>
><pre>
>• Adjusts buildUpdateDiagnosticCentreByOwnerParams to derive the centre’s available_tests string array from []TestPrices by extracting each TestType.
></pre>
>
><a href='https://github.com/QUDUSKUNLE/engine/pull/67/files#diff-a6e9cbf6536d968efc5eaafdbf26c8517882790834ad5f5d8be77cac2b32c156'>core/services/utils.services.go</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Refactor</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>payment.domain.go</strong> <code>Reorder payment method/provider constants</code> <code>+3/-3</code></summary>

<br/>

>Reorder payment method/provider constants
>
><pre>
>• Reorders constant declarations without changing values; behavior should remain the same.
></pre>
>
><a href='https://github.com/QUDUSKUNLE/engine/pull/67/files#diff-c34e057f72a16962296f06c83c60151dfe73c49f403036c6364675b40214cae0'>core/domain/payment.domain.go</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Documentation</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>diagnostic.go</strong> <code>Fix route description text</code> <code>+1/-1</code></summary>

<br/>

>Fix route description text
>
><pre>
>• Updates the route documentation string from singular to plural (Managers).
></pre>
>
><a href='https://github.com/QUDUSKUNLE/engine/pull/67/files#diff-41729683fee41cb0c0c2d16f7a4703f056c7a3c50e9be7ea813705c7eed583c6'>adapters/routes/diagnostic.go</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>